### PR TITLE
Refactor of LootRefiller mixin [1.20.1]

### DIFF
--- a/common/src/main/java/org/samo_lego/chestrefill/mixin/RandomizableContainerBEMixin_LootRefiller.java
+++ b/common/src/main/java/org/samo_lego/chestrefill/mixin/RandomizableContainerBEMixin_LootRefiller.java
@@ -161,7 +161,7 @@ public abstract class RandomizableContainerBEMixin_LootRefiller extends BaseCont
     private void refillLootTable(@Nullable Player player) {
         if (player != null) {
             if (this.lootTable == null && this.savedLootTable != null) {
-                boolean empty = isEmpty() || this.refillFull;
+                boolean empty = super.isEmpty() || this.refillFull;
                 if (empty && this.canRefillFor(player)) {
                     this.lootedUUIDs.add(player.getStringUUID());
                     // Refilling for player
@@ -246,7 +246,7 @@ public abstract class RandomizableContainerBEMixin_LootRefiller extends BaseCont
             // Save only if chest was looted (if there's no more original loot table)
             CompoundTag refillTag = new CompoundTag();
 
-            refillTag.putString("SavedLootTable", this.savedLootTable.toString());
+            refillTag.putString("SavedLootTable", this.savedLootTable.location().toString());
             refillTag.putLong("SavedLootTableSeed", this.savedLootTableSeed);
             refillTag.putInt("RefillCounter", this.refillCounter);
             refillTag.putLong("LastRefillTime", this.lastRefillTime);

--- a/common/src/main/java/org/samo_lego/chestrefill/mixin/RandomizableContainerBEMixin_LootRefiller.java
+++ b/common/src/main/java/org/samo_lego/chestrefill/mixin/RandomizableContainerBEMixin_LootRefiller.java
@@ -127,19 +127,8 @@ public abstract class RandomizableContainerBEMixin_LootRefiller implements Rando
      * @return true if the loot table was successfully loaded and set, false otherwise.
      */
     public boolean tryLoadLootTable(@NotNull CompoundTag compoundTag) {
-        if (compoundTag.contains(LOOT_TABLE_TAG, 8)) {
-            this.setLootTable(ResourceKey.create(Registries.LOOT_TABLE, ResourceLocation.parse(compoundTag.getString(LOOT_TABLE_TAG))));
-            if (compoundTag.contains(LOOT_TABLE_SEED_TAG, 4)) {
-                this.setLootTableSeed(compoundTag.getLong(LOOT_TABLE_SEED_TAG));
-            } else {
-                this.setLootTableSeed(0L);
-            }
-            this.onLootTableLoad(compoundTag);
-            return true;
-        } else {
-            this.onLootTableLoad(compoundTag);
-            return false;
-        }
+        this.onLootTableLoad(compoundTag);
+        return RandomizableContainer.super.tryLoadLootTable(compoundTag);
     }
 
     /**

--- a/common/src/main/java/org/samo_lego/chestrefill/mixin/RandomizableContainerBEMixin_LootRefiller.java
+++ b/common/src/main/java/org/samo_lego/chestrefill/mixin/RandomizableContainerBEMixin_LootRefiller.java
@@ -16,6 +16,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.storage.loot.LootTable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.samo_lego.chestrefill.PlatformHelper;
 import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -25,7 +26,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.samo_lego.chestrefill.ChestRefill.config;
-import static org.samo_lego.chestrefill.PlatformHelper.hasPermission;
 
 
 /**
@@ -43,11 +43,13 @@ import static org.samo_lego.chestrefill.PlatformHelper.hasPermission;
 public abstract class RandomizableContainerBEMixin_LootRefiller extends BaseContainerBlockEntity implements RandomizableContainer {
     protected RandomizableContainerBEMixin_LootRefiller(
             BlockEntityType<?> type,
-            BlockPos pos,
+            @NotNull BlockPos pos,
             BlockState blockState
            ) {
         super(type, pos, blockState);
     }
+
+
 
 // =-=-=-=-= Shadows =-=-=-=-=
     @Shadow
@@ -62,6 +64,8 @@ public abstract class RandomizableContainerBEMixin_LootRefiller extends BaseCont
 
     @Shadow
     public abstract void setLootTableSeed(long l);
+
+
 
 // =-=-=-=-= Unique Vars =-=-=-=-=
     @Unique
@@ -79,6 +83,8 @@ public abstract class RandomizableContainerBEMixin_LootRefiller extends BaseCont
     @Unique
     private int refillCounter, maxRefills;
 
+
+
 // =-=-=-=-= Injections/Overrides =-=-=-=-=
     @Inject(method = "<init>", at = @At("RETURN"))
     private void onInit(CallbackInfo ci) {
@@ -95,81 +101,9 @@ public abstract class RandomizableContainerBEMixin_LootRefiller extends BaseCont
     }
 
     public void unpackLootTable(@Nullable Player player) {
-        refillLootTable(player);
-        RandomizableContainer.super.unpackLootTable(player);
-    }
-
-    public boolean tryLoadLootTable(@NotNull CompoundTag compoundTag) {
-        this.onLootTableLoad(compoundTag);
-        return RandomizableContainer.super.tryLoadLootTable(compoundTag);
-    }
-
-    public boolean trySaveLootTable(CompoundTag compoundTag) {
-        this.onLootTableSave(compoundTag);
-        return RandomizableContainer.super.trySaveLootTable(compoundTag);
-    }
-
-// =-=-=-=-= Unique Checker Methods =-=-=-=-=
-    /**
-     * Whether container can be refilled for given player.
-     * <p>
-     * Checks for Player permissions,
-     * wether the storage can be refilled
-     * and whether enough time has passed since last refill.
-     *
-     * @param player player to check refilling for.
-     * @return true if all checks succeed, otherwise false.
-     * @see RandomizableContainerBEMixin_LootRefiller#canStillRefill
-     * @see RandomizableContainerBEMixin_LootRefiller#hasEnoughTimePassed
-     * @see RandomizableContainerBEMixin_LootRefiller#refillLootTable(Player)
-     */
-    @Unique
-    private boolean canRefillFor(@NotNull Player player) {
-        boolean relootPermission = hasPermission(player.createCommandSourceStack(), "chestrefill.allowReloot", this.allowRelootByDefault) || !this.lootedUUIDs.contains(player.getStringUUID());
-        return this.canStillRefill() && this.hasEnoughTimePassed() && relootPermission;
-    }
-
-
-    /**
-     * Whether this container hasn't reached max refills yet.
-     * @return true if container can still be refilled, false if refills is more than max refills.
-     */
-    @Unique
-    private boolean canStillRefill() {
-        return this.refillCounter < this.maxRefills || this.maxRefills == -1;
-    }
-
-    /**
-     * Tells whether enough time has passed since previous refill.
-     * @return true if container can already be refilled, otherwise false.
-     */
-    @Unique
-    private boolean hasEnoughTimePassed() {
-        // * 1000 as seconds are used in config.
-        return System.currentTimeMillis() - this.lastRefillTime > this.minWaitTime * 1000;
-    }
-
-// =-=-=-=-= Unique ChestRefill Methods =-=-=-=-=
-    /**
-     * Refills the loot table of the container.
-     *
-     * @param player The player opening the container. Can be null.
-     * @see RandomizableContainerBEMixin_LootRefiller#canRefillFor(Player)
-     * @see RandomizableContainerBEMixin_LootRefiller#unpackLootTable(Player)
-     */
-    @Unique
-    private void refillLootTable(@Nullable Player player) {
         if (player != null) {
             if (this.lootTable == null && this.savedLootTable != null) {
-                boolean empty = super.isEmpty() || this.refillFull;
-                if (empty && this.canRefillFor(player)) {
-                    this.lootedUUIDs.add(player.getStringUUID());
-                    // Refilling for player
-                    this.setLootTable(this.savedLootTable);
-                    this.setLootTableSeed(this.randomizeLootSeed ? player.getRandom().nextLong() : this.savedLootTableSeed);
-                    this.lastRefillTime = System.currentTimeMillis();
-                    ++refillCounter;
-                }
+                this.refillLootTable(player);
             } else {
                 // Original loot
                 this.lastRefillTime = System.currentTimeMillis();
@@ -181,93 +115,192 @@ public abstract class RandomizableContainerBEMixin_LootRefiller extends BaseCont
                 }
             }
         }
+
+        RandomizableContainer.super.unpackLootTable(player);
     }
 
-    /**
-     * Loads the loot table from the given compound tag and performs various operations based on the tag contents and configs.
-     *
-     * @param compoundTag The compound tag containing the loot table information.
-     */
-    @Unique
-    private void onLootTableLoad(@NotNull CompoundTag compoundTag) {
+    public boolean tryLoadLootTable(@NotNull CompoundTag compoundTag) {
         CompoundTag refillTag = compoundTag.getCompound("ChestRefill");
+
         if (!refillTag.isEmpty()) {
-            // Has been looted already but has saved loot table
-            this.savedLootTable = ResourceKey.create(Registries.LOOT_TABLE, ResourceLocation.parse(refillTag.getString("SavedLootTable")));
-            this.savedLootTableSeed = refillTag.getLong("SavedLootTableSeed");
-
-            this.refillCounter = refillTag.getInt("RefillCounter");
-            this.lastRefillTime = refillTag.getLong("LastRefillTime");
-
-            ListTag lootedUUIDsTag = (ListTag) refillTag.get("LootedUUIDs");
-            if(lootedUUIDsTag != null) {
-                lootedUUIDsTag.forEach(tag -> this.lootedUUIDs.add(tag.getAsString()));
-            }
-
-            // Per loot table customization
-            var modifiers = config.lootModifierMap.get(this.savedLootTable.toString());
-            if (modifiers == null) {
-                modifiers = config.lootModifierMap.get(this.savedLootTable.registry().getPath());
-            }
-
-            if(modifiers != null) {
-                // This loot table has special values set
-                this.randomizeLootSeed = modifiers.randomizeLootSeed;
-                this.refillFull = modifiers.refillFull;
-                this.allowRelootByDefault = modifiers.allowRelootByDefault;
-                this.maxRefills = modifiers.maxRefills;
-                this.minWaitTime = modifiers.minWaitTime;
-            }
-
-            // Per-chest customization
-            CompoundTag customValues = refillTag.getCompound("CustomValues");
-            if(!customValues.isEmpty()) {
-                this.hadCustomData = true;
-                this.randomizeLootSeed = customValues.getBoolean("RandomizeLootSeed");
-                this.refillFull = customValues.getBoolean("RefillNonEmpty");
-                this.allowRelootByDefault = customValues.getBoolean("AllowReloot");
-                this.maxRefills = customValues.getInt("MaxRefills");
-                this.minWaitTime = customValues.getLong("MinWaitTime");
-            }
+            this.loadRefillTags(refillTag);
         } else if (this.lootTable != null) {
             this.savedLootTable = this.lootTable;
             this.savedLootTableSeed = this.lootTableSeed;
         }
+
+        return RandomizableContainer.super.tryLoadLootTable(compoundTag);
+    }
+
+    public boolean trySaveLootTable(@NotNull CompoundTag compoundTag) {
+        if (this.lootTable == null && this.savedLootTable != null) {
+            this.saveRefillTags(compoundTag);
+        }
+
+        return RandomizableContainer.super.trySaveLootTable(compoundTag);
+    }
+
+
+
+// =-=-=-=-= Unique Checker Methods =-=-=-=-=
+    /**
+     * Whether container can be refilled for given player.
+     * <p>
+     * Checks for Player permissions,
+     * wether the storage can be refilled
+     * and whether enough time has passed since last refill.
+     *
+     * @param player player to check refilling for.
+     * @return <code>true</code> if all checks succeed, otherwise <code>false</code>.
+     * @see RandomizableContainerBEMixin_LootRefiller#canStillRefill()
+     * @see RandomizableContainerBEMixin_LootRefiller#hasPermission(Player)
+     * @see RandomizableContainerBEMixin_LootRefiller#hasEnoughTimePassed()
+     * @see RandomizableContainerBEMixin_LootRefiller#refillLootTable(Player)
+     */
+    @Unique
+    private boolean canRefillFor(@NotNull Player player) {
+        return this.canStillRefill() && this.hasEnoughTimePassed() && this.hasPermission(player);
     }
 
     /**
-     * Saves the loot table information to a CompoundTag.
-     *
-     * @param compoundTag The CompoundTag to save the loot table information to.
+     * Whether a player has permission to reloot from this storage.
+     * @param player Player opening the storage
+     * @return <code>true</code> if the player has the <code>chestrefill.allowReloot</code> permission node or hasn't looted this storage. otherwise <code>false</code>.
      */
     @Unique
-    private void onLootTableSave(CompoundTag compoundTag) {
-        if (this.lootTable == null && this.savedLootTable != null) {
-            // Save only if chest was looted (if there's no more original loot table)
-            CompoundTag refillTag = new CompoundTag();
+    private boolean hasPermission(@NotNull Player player) {
+        return PlatformHelper.hasPermission(
+                player.createCommandSourceStack(),
+                "chestrefill.allowReloot",
+                this.allowRelootByDefault) || !this.lootedUUIDs.contains(player.getStringUUID()
+        );
+    }
 
-            refillTag.putString("SavedLootTable", this.savedLootTable.location().toString());
-            refillTag.putLong("SavedLootTableSeed", this.savedLootTableSeed);
-            refillTag.putInt("RefillCounter", this.refillCounter);
-            refillTag.putLong("LastRefillTime", this.lastRefillTime);
+    /**
+     * Whether this container hasn't reached max refills yet.
+     * @return <code>true</code> if container can still be refilled, <code>false</code> if refills is more than max refills.
+     */
+    @Unique
+    private boolean canStillRefill() {
+        return this.refillCounter < this.maxRefills || this.maxRefills == -1;
+    }
 
-            ListTag lootedUUIDsTag = new ListTag();
-            this.lootedUUIDs.forEach(uuid -> lootedUUIDsTag.add(StringTag.valueOf(uuid)));
-            refillTag.put("LootedUUIDs", lootedUUIDsTag);
+    /**
+     * Tells whether enough time has passed since previous refill.
+     * @return <code>true</code> if container can already be refilled, otherwise <code>false</code>.
+     */
+    @Unique
+    private boolean hasEnoughTimePassed() {
+        // * 1000 as seconds are used in config.
+        return System.currentTimeMillis() - this.lastRefillTime > this.minWaitTime * 1000;
+    }
 
-            // Allows per-chest customization
-            if (this.hadCustomData) {
-                CompoundTag customValues = new CompoundTag();
 
-                customValues.putBoolean("RandomizeLootSeed", this.randomizeLootSeed);
-                customValues.putBoolean("RefillNonEmpty", this.refillFull);
-                customValues.putBoolean("AllowReloot", this.allowRelootByDefault);
-                customValues.putInt("MaxRefills", this.maxRefills);
-                customValues.putLong("MinWaitTime", this.minWaitTime);
-                refillTag.put("CustomValues", customValues);
-            }
 
-            compoundTag.put("ChestRefill", refillTag);
+// =-=-=-=-= Unique ChestRefill Methods =-=-=-=-=
+    /**
+     * Refills the loot table of the container.
+     * <p>
+     * Only refills if: <ul>
+     *     <li> The container is empty or can be refilled while full </li>
+     *     <li> The container can be filled for the player </li>
+     * </ul>
+     *
+     *
+     * @param player The player opening the container.
+     * @see RandomizableContainerBEMixin_LootRefiller#canRefillFor(Player)
+     * @see RandomizableContainerBEMixin_LootRefiller#unpackLootTable(Player)
+     */
+    @Unique
+    private void refillLootTable(@NotNull Player player) {
+        boolean empty = super.isEmpty() || this.refillFull;
+        if (empty && this.canRefillFor(player)) {
+            this.lootedUUIDs.add(player.getStringUUID());
+            // Refilling for player
+            this.setLootTable(this.savedLootTable);
+            this.setLootTableSeed(this.randomizeLootSeed ? player.getRandom().nextLong() : this.savedLootTableSeed);
+            this.lastRefillTime = System.currentTimeMillis();
+            ++refillCounter;
         }
+    }
+
+    /**
+     * Loads the refilling options from the given compound tag and performs various operations based on the tag contents and configs.
+     *
+     * @param refillTag The compound tag containing the refilling options.
+     */
+    @Unique
+    private void loadRefillTags(@NotNull CompoundTag refillTag) {
+        // Has been looted already but has saved loot table
+        this.savedLootTable = ResourceKey.create(Registries.LOOT_TABLE, ResourceLocation.parse(refillTag.getString("SavedLootTable")));
+        this.savedLootTableSeed = refillTag.getLong("SavedLootTableSeed");
+
+        this.refillCounter = refillTag.getInt("RefillCounter");
+        this.lastRefillTime = refillTag.getLong("LastRefillTime");
+
+        ListTag lootedUUIDsTag = (ListTag) refillTag.get("LootedUUIDs");
+        if(lootedUUIDsTag != null) {
+            lootedUUIDsTag.forEach(tag -> this.lootedUUIDs.add(tag.getAsString()));
+        }
+
+        // Per loot table customization
+        var modifiers = config.lootModifierMap.get(this.savedLootTable.location().toString());
+        if (modifiers == null) {
+            modifiers = config.lootModifierMap.get(this.savedLootTable.registry().getPath());
+        }
+
+        if(modifiers != null) {
+            // This loot table has special values set
+            this.randomizeLootSeed = modifiers.randomizeLootSeed;
+            this.refillFull = modifiers.refillFull;
+            this.allowRelootByDefault = modifiers.allowRelootByDefault;
+            this.maxRefills = modifiers.maxRefills;
+            this.minWaitTime = modifiers.minWaitTime;
+        }
+
+        // Per-chest customization
+        CompoundTag customValues = refillTag.getCompound("CustomValues");
+        if(!customValues.isEmpty()) {
+            this.hadCustomData = true;
+            this.randomizeLootSeed = customValues.getBoolean("RandomizeLootSeed");
+            this.refillFull = customValues.getBoolean("RefillNonEmpty");
+            this.allowRelootByDefault = customValues.getBoolean("AllowReloot");
+            this.maxRefills = customValues.getInt("MaxRefills");
+            this.minWaitTime = customValues.getLong("MinWaitTime");
+        }
+    }
+
+    /**
+     * Saves the refill options to a CompoundTag.
+     *
+     * @param compoundTag The CompoundTag to save the refill options to.
+     */
+    @Unique
+    private void saveRefillTags(@NotNull CompoundTag compoundTag) {
+        // Save only if chest was looted (if there's no more original loot table)
+        CompoundTag refillTag = new CompoundTag();
+
+        refillTag.putString("SavedLootTable", this.savedLootTable.location().toString());
+        refillTag.putLong("SavedLootTableSeed", this.savedLootTableSeed);
+        refillTag.putInt("RefillCounter", this.refillCounter);
+        refillTag.putLong("LastRefillTime", this.lastRefillTime);
+
+        ListTag lootedUUIDsTag = new ListTag();
+        this.lootedUUIDs.forEach(uuid -> lootedUUIDsTag.add(StringTag.valueOf(uuid)));
+        refillTag.put("LootedUUIDs", lootedUUIDsTag);
+
+        // Allows per-chest customization
+        if (this.hadCustomData) {
+            CompoundTag customValues = new CompoundTag();
+
+            customValues.putBoolean("RandomizeLootSeed", this.randomizeLootSeed);
+            customValues.putBoolean("RefillNonEmpty", this.refillFull);
+            customValues.putBoolean("AllowReloot", this.allowRelootByDefault);
+            customValues.putInt("MaxRefills", this.maxRefills);
+            customValues.putLong("MinWaitTime", this.minWaitTime);
+            refillTag.put("CustomValues", customValues);
+        }
+
+        compoundTag.put("ChestRefill", refillTag);
     }
 }


### PR DESCRIPTION
fixes issues with https://github.com/samolego/ChestRefill/pull/9#issuecomment-2600895017

This PR does a bunch of refactors to the mixin in an attempt to simplify debugging and maintenance.

The issue in #9 happened due to a missing method call causing the savedLootTable to be saved as `ResourceKey` instead of a `ResourceLocation`.